### PR TITLE
FEATURE: GDP-979 Deprecation of yaml on public resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.gooddata.agent</groupId>
 	<artifactId>gdc-agent</artifactId>
 	<packaging>jar</packaging>
-	<version>0.10.0</version>
+	<version>0.11.0-snapshot</version>
 	<name>GoodData Agent</name>
 	<url>http://maven.apache.org</url>
 	<properties>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>com.gooddata</groupId>
 			<artifactId>gooddata-java</artifactId>
-			<version>2.6.0</version>
+			<version>2.35.0+api1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.awaitility</groupId>


### PR DESCRIPTION
* version of GoodData java SDK updated so that no yaml is used any more